### PR TITLE
Chore: Add Multiple Component Name instance to Playground

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ remarkPlugins: [[remarkSandpack, { componentName: 'SandpackEnhanced' }]],
 
 Additionally, you can pass an array of component names if you want to support multiple components. For instance:
 
-```
+```js
 // in your mdx config
 remarkPlugins: [[remarkSandpack, { componentName: ['SandpackEnhanced', 'AnotherSandpackComponent'] }]],
 ```

--- a/playground/codes/folder2/src/index.js
+++ b/playground/codes/folder2/src/index.js
@@ -1,0 +1,5 @@
+import './styles.css';
+
+document.getElementById('app').innerHTML = `
+<h2>Sandpack is Awesome! Right??</h2>
+`;

--- a/playground/codes/folder2/src/styles.css
+++ b/playground/codes/folder2/src/styles.css
@@ -1,0 +1,3 @@
+h2 {
+  background-color: #cce8ff;
+}

--- a/playground/components/CustomSandpack.tsx
+++ b/playground/components/CustomSandpack.tsx
@@ -1,0 +1,1 @@
+export { Sandpack as CustomSandpack } from '@codesandbox/sandpack-react';

--- a/playground/next.config.js
+++ b/playground/next.config.js
@@ -4,7 +4,7 @@ const { remarkSandpack } = require('remark-sandpack');
 const withMDX = require('@next/mdx')({
   extension: /\.mdx?$/,
   options: {
-    remarkPlugins: [remarkSandpack],
+    remarkPlugins: [[remarkSandpack, { componentName: ['Sandpack', 'CustomSandpack'] }]],
     rehypePlugins: [],
     // If you use `MDXProvider`, uncomment the following line.
     // providerImportSource: "@mdx-js/react",

--- a/playground/pages/index.mdx
+++ b/playground/pages/index.mdx
@@ -1,11 +1,20 @@
 ## MDX123
 
 import { Sandpack } from '@codesandbox/sandpack-react';
+import { CustomSandpack } from '../components/CustomSandpack';
 
 <Sandpack template="vanilla">
 ```dir=codes/folder1
 ```
 
 ```src/styles.css active
+
 ```
+
 </Sandpack>
+
+<CustomSandpack template="vanilla">
+```dir=codes/folder2
+```
+
+</CustomSandpack>


### PR DESCRIPTION
### Description
Update the playground folder with a multiple component name example.

### Screenshot
<img width="1792" alt="Multiple component names" src="https://github.com/user-attachments/assets/372e9c6e-7307-47ab-a540-84e98dc8393e">
